### PR TITLE
Material bootsrap library

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ Expo has a menu you can open from the iOS/Android emulator by pressing ``CMD + D
 
 ![expomenu](./art/expoMenu.png)
 
+## Running tests
+
+We've added some tests to our playground so you can use the following commands to run our test cases:
+
+```
+yarn test # Runs every test
+yarn testWatching # Starts a jest watcher running the tests just for the code you've changed.
+yarn updateSnapshots # Updates all the snapshots recorded using jest.
+```
+
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ List of pull requests:
 * [How to configure Travis CI.](https://github.com/Karumi/ReactNativePlayground/pull/2)
 * [How to add Typescript and Jest support](https://github.com/Karumi/ReactNativePlayground/pull/3)
 * [Configure a crash reporter tool (Sentry)](https://github.com/Karumi/ReactNativePlayground/pull/4)
+* [Configure a Native Base library and create our own components.](https://github.com/Karumi/ReactNativePlayground/pull/5)
 
 ## How to run this app
 

--- a/app/App.js
+++ b/app/App.js
@@ -1,6 +1,40 @@
-import App from './src/App';
-import Sentry from 'sentry-expo';
+import React from "react";
+import App from "./src/App";
+import Sentry from "sentry-expo";
+import Expo from "expo";
 
-Sentry.config('https://b2ba5e1a6cbf4ff79a89291db6ecc3fb@sentry.io/1298369').install();
+class ReactNativePlaygroundApp extends React.Component {
+    constructor(props) {
+        super(props)
+        this.state = { loading: true };
+    }
 
-export default App;
+    async componentWillMount() {
+        this.initializeSentry();
+        await this.initializeNativeBaseFonts();
+        this.setState({ loading: false });
+    }
+
+    render() {
+        if (this.state.loading) {
+            return <Expo.AppLoading />;
+        } else {
+            return (<App />);
+        }
+
+    }
+
+    initializeSentry() {
+        Sentry.config('https://b2ba5e1a6cbf4ff79a89291db6ecc3fb@sentry.io/1298369').install();
+    }
+
+    initializeNativeBaseFonts() {
+        return Expo.Font.loadAsync({
+            'Roboto': require('native-base/Fonts/Roboto.ttf'),
+            'Roboto_medium': require('native-base/Fonts/Roboto_medium.ttf'),
+            'Ionicons': require('@expo/vector-icons/fonts/Ionicons.ttf'),
+        });
+    }
+}
+
+export default ReactNativePlaygroundApp;

--- a/app/app.json
+++ b/app/app.json
@@ -26,6 +26,9 @@
     "android": {
       "package": "com.karumi.reactnativeplayground"
     },
+    "androidStatusBar": {
+        "barStyle": "light-content"
+    },
     "packagerOpts": {
       "assetExts": [
         "ttf",

--- a/app/package.json
+++ b/app/package.json
@@ -8,10 +8,11 @@
     "ios": "expo start --ios",
     "eject": "expo eject",
     "lint": "eslint . && tslint -c tslint.json 'src/**/*.{ts,tsx}'",
+    "fixLint": "eslint --fix . && tslint -c tslint.json 'src/**/*.{ts,tsx}' --fix",
     "clean": "rimraf artifacts",
     "test": "jest",
     "testWatching": "jest --watch",
-    "fixLint": "eslint --fix . && tslint -c tslint.json 'src/**/*.{ts,tsx}' --fix"
+    "updateSnapshots": "jest --updateSnapshot"
   },
   "dependencies": {
     "@expo/vector-icons": "^8.0.0",
@@ -62,7 +63,7 @@
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "transformIgnorePatterns": [
-      "node_modules/(?!(expo-react-native-adapter|react-native|lottie-react-native|expo|react-native-maps|react-native-svg|react-native-branch|native-base-shoutem-theme|react-native-easy-grid|react-native-drawer|react-native-vector-icons|react-native-keyboard-aware-scroll-view|react-navigation|native-base|@expo|react-native-scrollable-tab-view)/)"
+      "node_modules/(?!(expo-react-native-adapter|react-native-iphone-x-helper|native-base|react-native|lottie-react-native|expo|react-native-maps|react-native-svg|react-native-branch|native-base-shoutem-theme|react-native-easy-grid|react-native-drawer|react-native-vector-icons|react-native-keyboard-aware-scroll-view|react-navigation|native-base|@expo|react-native-scrollable-tab-view)/)"
     ]
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,9 @@
     "fixLint": "eslint --fix . && tslint -c tslint.json 'src/**/*.{ts,tsx}' --fix"
   },
   "dependencies": {
+    "@expo/vector-icons": "^8.0.0",
     "expo": "^30.0.1",
+    "native-base": "^2.8.1",
     "react": "16.3.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-30.0.0.tar.gz",
     "sentry-expo": "^1.10.0",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -8,7 +8,7 @@ export default class App extends React.Component {
     return (
       <Container>
         <Toolbar/>
-        <Text>Open up App.js to start working on your app usign Typescript and Jest</Text>
+        <Text>Open up App.js to start working on your app usign Typescript and Jest!</Text>
       </Container>
     );
   }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,23 +1,15 @@
+import { Container } from "native-base";
 import * as React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { Text } from "react-native";
+import Toolbar from "./base-components/Toolbar";
 
 export default class App extends React.Component {
   public render() {
     return (
-      <View style={styles.container}>
-        <Text>Open up App.js to start working on your app usign Typescript and Jest!</Text>
-      </View>
+      <Container>
+        <Toolbar/>
+        <Text>Open up App.js to start working on your app usign Typescript and Jest</Text>
+      </Container>
     );
   }
 }
-
-const defaultBackgroundColor = "#FFF";
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: defaultBackgroundColor,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-});

--- a/app/src/__tests__/App.test.tsx
+++ b/app/src/__tests__/App.test.tsx
@@ -1,7 +1,12 @@
 import * as React from "react";
 import * as renderer from "react-test-renderer";
-
 import App from "../App";
+
+jest.mock("../base-components/Toolbar", () => {
+    return {
+      default: "Toolbar",
+    };
+} );
 
 it("renders correctly with defaults", () => {
     const app = renderer.create(<App />).toJSON();

--- a/app/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/app/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -10,70 +10,13 @@ exports[`renders correctly with defaults 1`] = `
     }
   }
 >
-  <View
-    onLayout={[Function]}
-  >
-    <View
-      style={
-        Object {
-          "backgroundColor": "#F8F8F8",
-          "borderBottomColor": "#a7a6ab",
-          "borderBottomWidth": 0.5,
-          "elevation": 3,
-          "flexDirection": "row",
-          "height": 64,
-          "justifyContent": "center",
-          "left": 0,
-          "paddingLeft": 6,
-          "paddingRight": 10,
-          "paddingTop": 18,
-          "right": 0,
-          "shadowColor": undefined,
-          "shadowOffset": undefined,
-          "shadowOpacity": undefined,
-          "shadowRadius": undefined,
-          "top": 0,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "alignSelf": "center",
-            "flex": 1,
-          }
-        }
-      >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-          numberOfLines={1}
-          style={
-            Object {
-              "color": "#000",
-              "fontFamily": "System",
-              "fontSize": 17,
-              "fontWeight": "700",
-              "marginLeft": undefined,
-              "paddingLeft": 4,
-              "paddingTop": 1,
-              "textAlign": "center",
-            }
-          }
-        >
-          React Native Playground
-        </Text>
-      </View>
-    </View>
-  </View>
+  <Toolbar />
   <Text
     accessible={true}
     allowFontScaling={true}
     ellipsizeMode="tail"
   >
-    Open up App.js to start working on your app usign Typescript and Jest
+    Open up App.js to start working on your app usign Typescript and Jest!
   </Text>
 </View>
 `;

--- a/app/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/app/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -4,19 +4,76 @@ exports[`renders correctly with defaults 1`] = `
 <View
   style={
     Object {
-      "alignItems": "center",
-      "backgroundColor": "#FFF",
+      "backgroundColor": "#fff",
       "flex": 1,
-      "justifyContent": "center",
+      "height": 1334,
     }
   }
 >
+  <View
+    onLayout={[Function]}
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F8F8F8",
+          "borderBottomColor": "#a7a6ab",
+          "borderBottomWidth": 0.5,
+          "elevation": 3,
+          "flexDirection": "row",
+          "height": 64,
+          "justifyContent": "center",
+          "left": 0,
+          "paddingLeft": 6,
+          "paddingRight": 10,
+          "paddingTop": 18,
+          "right": 0,
+          "shadowColor": undefined,
+          "shadowOffset": undefined,
+          "shadowOpacity": undefined,
+          "shadowRadius": undefined,
+          "top": 0,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "alignSelf": "center",
+            "flex": 1,
+          }
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          numberOfLines={1}
+          style={
+            Object {
+              "color": "#000",
+              "fontFamily": "System",
+              "fontSize": 17,
+              "fontWeight": "700",
+              "marginLeft": undefined,
+              "paddingLeft": 4,
+              "paddingTop": 1,
+              "textAlign": "center",
+            }
+          }
+        >
+          React Native Playground
+        </Text>
+      </View>
+    </View>
+  </View>
   <Text
     accessible={true}
     allowFontScaling={true}
     ellipsizeMode="tail"
   >
-    Open up App.js to start working on your app usign Typescript and Jest!
+    Open up App.js to start working on your app usign Typescript and Jest
   </Text>
 </View>
 `;

--- a/app/src/base-components/Toolbar.tsx
+++ b/app/src/base-components/Toolbar.tsx
@@ -1,0 +1,16 @@
+import {  Body, Header, Title } from "native-base";
+import * as React from "react";
+
+class Toolbar extends React.Component {
+    public render() {
+        return (
+            <Header>
+                <Body>
+                    <Title>React Native Playground</Title>
+                </Body>
+            </Header>
+        );
+    }
+}
+
+export default Toolbar;

--- a/app/src/base-components/__tests__/Toolbar.test.tsx
+++ b/app/src/base-components/__tests__/Toolbar.test.tsx
@@ -1,0 +1,9 @@
+
+import * as React from "react";
+import * as renderer from "react-test-renderer";
+import Toolbar from "../Toolbar";
+
+it("renders correctly with defaults", () => {
+    const toolbar = renderer.create(<Toolbar />).toJSON();
+    expect(toolbar).toMatchSnapshot();
+});

--- a/app/src/base-components/__tests__/__snapshots__/Toolbar.test.tsx.snap
+++ b/app/src/base-components/__tests__/__snapshots__/Toolbar.test.tsx.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly with defaults 1`] = `
+<View
+  onLayout={[Function]}
+>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#F8F8F8",
+        "borderBottomColor": "#a7a6ab",
+        "borderBottomWidth": 0.5,
+        "elevation": 3,
+        "flexDirection": "row",
+        "height": 64,
+        "justifyContent": "center",
+        "left": 0,
+        "paddingLeft": 6,
+        "paddingRight": 10,
+        "paddingTop": 18,
+        "right": 0,
+        "shadowColor": undefined,
+        "shadowOffset": undefined,
+        "shadowOpacity": undefined,
+        "shadowRadius": undefined,
+        "top": 0,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "center",
+          "flex": 1,
+        }
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        numberOfLines={1}
+        style={
+          Object {
+            "color": "#000",
+            "fontFamily": "System",
+            "fontSize": 17,
+            "fontWeight": "700",
+            "marginLeft": undefined,
+            "paddingLeft": 4,
+            "paddingTop": 1,
+            "textAlign": "center",
+          }
+        }
+      >
+        React Native Playground
+      </Text>
+    </View>
+  </View>
+</View>
+`;

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -442,6 +442,13 @@
     lodash "^4.17.4"
     react-native-vector-icons "4.5.0"
 
+"@expo/vector-icons@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-8.0.0.tgz#29c91778aee02b92b045914bbed8eec299a84e5e"
+  dependencies:
+    lodash "^4.17.4"
+    react-native-vector-icons "6.0.0"
+
 "@expo/websql@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@expo/websql/-/websql-1.0.1.tgz#fff0cf9c1baa1f70f9e1d658b7c39a420d9b10a9"
@@ -633,7 +640,7 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
-ansi-styles@^2.2.1:
+ansi-styles@^2.1.0, ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
@@ -1576,6 +1583,10 @@ big-integer@^1.6.7:
   version "1.6.36"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.36.tgz#78631076265d4ae3555c04f85e7d9d2f3a071a36"
 
+blueimp-md5@^2.5.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.10.0.tgz#02f0843921f90dca14f5b8920a38593201d6964d"
+
 bplist-creator@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.0.7.tgz#37df1536092824b87c42f957b01344117372ae45"
@@ -1713,6 +1724,16 @@ caseless@^0.12.0, caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
+chalk@1.1.1:
+  version "1.1.1"
+  resolved "http://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz#509afb67066e7499f7eb3535c77445772ae2d019"
+  dependencies:
+    ansi-styles "^2.1.0"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
+
 chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1750,6 +1771,10 @@ ci-info@^1.5.0:
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+
+clamp@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/clamp/-/clamp-1.0.1.tgz#66a0e64011816e37196828fdc8c8c147312c8634"
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -1808,7 +1833,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0, color-convert@^1.9.1:
+color-convert@^1.8.2, color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   dependencies:
@@ -1822,7 +1847,7 @@ color-name@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
 
-color-string@^1.5.2:
+color-string@^1.4.0, color-string@^1.5.2:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.3.tgz#c9bbc5f01b58b5492f3d6857459cb6590ce204cc"
   dependencies:
@@ -1839,6 +1864,13 @@ color@^2.0.1:
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.2"
+
+color@~1.0.3:
+  version "1.0.3"
+  resolved "http://registry.npmjs.org/color/-/color-1.0.3.tgz#e48e832d85f14ef694fb468811c2d5cfe729b55d"
+  dependencies:
+    color-convert "^1.8.2"
+    color-string "^1.4.0"
 
 combined-stream@1.0.6:
   version "1.0.6"
@@ -3070,6 +3102,13 @@ fs-extra@^1.0.0:
     jsonfile "^2.1.0"
     klaw "^1.0.0"
 
+fs-extra@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -3273,6 +3312,10 @@ has@^1.0.1, has@^1.0.3:
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   dependencies:
     function-bind "^1.1.1"
+
+hoist-non-react-statics@^1.0.5:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
 hoist-non-react-statics@^2.3.1:
   version "2.5.5"
@@ -4063,6 +4106,10 @@ jest-mock@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
 
+jest-react-native@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/jest-react-native/-/jest-react-native-18.0.0.tgz#77dd909f069324599f227c58c61c2e62168726ba"
+
 jest-regex-util@^22.1.0, jest-regex-util@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-22.4.3.tgz#a826eb191cdf22502198c5401a1fc04de9cef5af"
@@ -4571,11 +4618,15 @@ lodash.zipobject@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lodash.zipobject/-/lodash.zipobject-4.1.3.tgz#b399f5aba8ff62a746f6979bf20b214f964dbef8"
 
+lodash@4.17.10:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
 lodash@^3.5.0:
   version "3.10.1"
   resolved "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.16.6, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.10.1, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.16.6, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -4960,6 +5011,34 @@ nanomatch@^1.2.9:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+native-base-shoutem-theme@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/native-base-shoutem-theme/-/native-base-shoutem-theme-0.2.2.tgz#5823310455fe391adf72236469c039fd44f56a20"
+  dependencies:
+    hoist-non-react-statics "^1.0.5"
+    lodash "^4.10.1"
+    prop-types "^15.5.10"
+
+native-base@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/native-base/-/native-base-2.8.1.tgz#8004a9dcfb69284137741857c3db880788f65581"
+  dependencies:
+    blueimp-md5 "^2.5.0"
+    clamp "^1.0.1"
+    color "~1.0.3"
+    fs-extra "^2.0.0"
+    jest-react-native "^18.0.0"
+    lodash "4.17.10"
+    native-base-shoutem-theme "0.2.2"
+    print-message "^2.1.0"
+    prop-types "^15.5.10"
+    react-native-drawer "2.5.0"
+    react-native-easy-grid "0.2.0"
+    react-native-keyboard-aware-scroll-view "0.5.0"
+    react-native-vector-icons "4.6.0"
+    react-tween-state "^0.1.5"
+    tween-functions "^1.0.1"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -5470,6 +5549,12 @@ pretty-format@^4.2.1:
   version "4.3.1"
   resolved "http://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz#530be5c42b3c05b36414a7a2a4337aa80acd0e8d"
 
+print-message@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/print-message/-/print-message-2.1.0.tgz#b5588ed08b0e1bf77ac7bcb5cb78004afaf9a891"
+  dependencies:
+    chalk "1.1.1"
+
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -5538,6 +5623,12 @@ r2@^2.0.1:
     node-fetch "^2.0.0-alpha.8"
     typedarray-to-buffer "^3.1.2"
 
+raf@^3.1.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
+  dependencies:
+    performance-now "^2.1.0"
+
 randomatic@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.0.tgz#36f2ca708e9e567f5ed2ec01949026d50aa10116"
@@ -5586,6 +5677,19 @@ react-native-branch@2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/react-native-branch/-/react-native-branch-2.2.5.tgz#4074dd63b4973e6397d9ce50e97b57c77a518e9d"
 
+react-native-drawer@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-drawer/-/react-native-drawer-2.5.0.tgz#022cba5c0516126a9fc9cce3185cb46c644b51c4"
+  dependencies:
+    prop-types "^15.5.8"
+    tween-functions "^1.0.1"
+
+react-native-easy-grid@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-easy-grid/-/react-native-easy-grid-0.2.0.tgz#4718031aa1baaa2613b829fc807da288eb0d2797"
+  dependencies:
+    lodash "^4.11.1"
+
 react-native-gesture-handler@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.0.6.tgz#8a672ca0c7a1b706dffee4e230e5cf0197d2cdb8"
@@ -5593,6 +5697,17 @@ react-native-gesture-handler@1.0.6:
     hoist-non-react-statics "^2.3.1"
     invariant "^2.2.2"
     prop-types "^15.5.10"
+
+react-native-iphone-x-helper@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.0.tgz#9f8a376eb00bc712115abff4420318a0063fa796"
+
+react-native-keyboard-aware-scroll-view@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.5.0.tgz#57ab933089375bf62f4324797e8be949ad97849d"
+  dependencies:
+    prop-types "^15.6.0"
+    react-native-iphone-x-helper "^1.0.1"
 
 react-native-maps@0.21.0:
   version "0.21.0"
@@ -5646,6 +5761,22 @@ react-native-vector-icons@4.5.0:
   dependencies:
     lodash "^4.0.0"
     prop-types "^15.5.10"
+    yargs "^8.0.2"
+
+react-native-vector-icons@4.6.0:
+  version "4.6.0"
+  resolved "http://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-4.6.0.tgz#e4014311ffa6de397d914ffc31b7097a874cc8d5"
+  dependencies:
+    lodash "^4.0.0"
+    prop-types "^15.5.10"
+    yargs "^8.0.2"
+
+react-native-vector-icons@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-6.0.0.tgz#3a7076dbe244ea94c6d5e92802a870e64a4283c5"
+  dependencies:
+    lodash "^4.0.0"
+    prop-types "^15.6.2"
     yargs "^8.0.2"
 
 "react-native@https://github.com/expo/react-native/archive/sdk-30.0.0.tar.gz":
@@ -5737,6 +5868,13 @@ react-transform-hmr@^1.0.4:
   dependencies:
     global "^4.3.0"
     react-proxy "^1.1.7"
+
+react-tween-state@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/react-tween-state/-/react-tween-state-0.1.5.tgz#e98b066551efb93cb92dd1be14995c2e3deae339"
+  dependencies:
+    raf "^3.1.0"
+    tween-functions "^1.0.1"
 
 react@16.3.1:
   version "16.3.1"
@@ -6604,6 +6742,10 @@ tunnel-agent@^0.6.0:
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
   dependencies:
     safe-buffer "^5.0.1"
+
+tween-functions@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tween-functions/-/tween-functions-1.2.0.tgz#1ae3a50e7c60bb3def774eac707acbca73bbc3ff"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
### :tophat: What is the goal?

Add a really cool library named [NativeBase](https://nativebase.io/) needed to use material-ui components and create our very first own component

### How is it being implemented?

First, we've configured ``NativeBase`` library as described in their documentation. After that, we've created our own component using a class extending from ``React.Component`` where the ``render`` method has been implemented using a ``NativeBase`` ``Header`` component.

We've also written a new test case and added a mock for the toolbar in the main app test case we wrote in another PR.

This is how the UI looks like right now in Android and iOS

<img width="396" alt="android" src="https://user-images.githubusercontent.com/4030704/46797326-2a43d880-cd4f-11e8-9eb9-e279b7fa28cf.png">

![simulator screen shot - iphone x - 2018-10-11 at 12 14 18](https://user-images.githubusercontent.com/4030704/46797341-2fa12300-cd4f-11e8-9d29-567d4d89675c.png)

### How can it be tested?

Automatically! :robot: I've added some automated tests I'd recommend you to review :smiley: