### PR TITLE
Add support for i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ List of pull requests:
 * [Configure a crash reporter tool (Sentry).](https://github.com/Karumi/ReactNativePlayground/pull/4)
 * [Configure a splash screen.](https://github.com/Karumi/ReactNativePlayground/pull/5)
 * [Configure a Native Base library and create our own components.](https://github.com/Karumi/ReactNativePlayground/pull/6)
+* [App localization.](https://github.com/Karumi/ReactNativePlayground/pull/7)
 
 ## How to run this app
 

--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,9 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^8.0.0",
+    "ex-react-native-i18n": "^0.0.4",
     "expo": "^30.0.1",
+    "i18n-ts": "^1.0.2",
     "native-base": "^2.8.1",
     "react": "16.3.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-30.0.0.tar.gz",

--- a/app/src/base-components/Toolbar.tsx
+++ b/app/src/base-components/Toolbar.tsx
@@ -1,13 +1,13 @@
 import {  Body, Header, Title } from "native-base";
 import * as React from "react";
-import t from "../i18n";
+import translator from "../i18n";
 
 class Toolbar extends React.Component {
     public render() {
         return (
             <Header>
                 <Body>
-                    <Title>{t.appName}</Title>
+                    <Title>{translator().appName}</Title>
                 </Body>
             </Header>
         );

--- a/app/src/base-components/Toolbar.tsx
+++ b/app/src/base-components/Toolbar.tsx
@@ -1,12 +1,13 @@
 import {  Body, Header, Title } from "native-base";
 import * as React from "react";
+import t from "../i18n";
 
 class Toolbar extends React.Component {
     public render() {
         return (
             <Header>
                 <Body>
-                    <Title>React Native Playground</Title>
+                    <Title>{t.appName}</Title>
                 </Body>
             </Header>
         );

--- a/app/src/base-components/__tests__/Toolbar.test.tsx
+++ b/app/src/base-components/__tests__/Toolbar.test.tsx
@@ -1,6 +1,7 @@
 
 import * as React from "react";
 import * as renderer from "react-test-renderer";
+import "../../test-utils/fake-i18n";
 import Toolbar from "../Toolbar";
 
 it("renders correctly with defaults", () => {

--- a/app/src/base-components/__tests__/__snapshots__/Toolbar.test.tsx.snap
+++ b/app/src/base-components/__tests__/__snapshots__/Toolbar.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`renders correctly with defaults 1`] = `
           }
         }
       >
-        React Native Playground
+        React Native Playground EN
       </Text>
     </View>
   </View>

--- a/app/src/foo.js
+++ b/app/src/foo.js
@@ -1,3 +1,0 @@
-export default class Foo {
-
-}

--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -3,11 +3,21 @@ import { I18nResolver } from "i18n-ts";
 import en from "./translations/en";
 import es from "./translations/es";
 
+I18n.initAsync();
+I18n.fallbacks = true;
+
 const i18n = {
     en,
     es,
     default: en,
  };
 
-const messages = new I18nResolver(i18n,  I18n.locale).translation;
-export default messages;
+let i18nResolver = null;
+
+const translator = () => {
+    if (i18nResolver === null) {
+        i18nResolver = new I18nResolver(i18n,  I18n.locale).translation;
+    }
+    return i18nResolver;
+};
+export default translator;

--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -1,0 +1,13 @@
+import I18n from "ex-react-native-i18n";
+import { I18nResolver } from "i18n-ts";
+import en from "./translations/en";
+import es from "./translations/es";
+
+const i18n = {
+    en,
+    es,
+    default: en,
+ };
+
+const messages = new I18nResolver(i18n,  I18n.locale).translation;
+export default messages;

--- a/app/src/test-utils/fake-i18n.ts
+++ b/app/src/test-utils/fake-i18n.ts
@@ -6,6 +6,6 @@ const i18n = { default: en };
 
 jest.mock("../i18n", () => {
 return {
-        default: new I18nResolver(i18n,  "en").translation,
+        default: () => new I18nResolver(i18n,  "en").translation,
     };
 } );

--- a/app/src/test-utils/fake-i18n.ts
+++ b/app/src/test-utils/fake-i18n.ts
@@ -1,0 +1,11 @@
+
+import { I18nResolver } from "i18n-ts";
+import en from "../translations/en";
+
+const i18n = { default: en };
+
+jest.mock("../i18n", () => {
+return {
+        default: new I18nResolver(i18n,  "en").translation,
+    };
+} );

--- a/app/src/translations/en.ts
+++ b/app/src/translations/en.ts
@@ -1,0 +1,5 @@
+const en = {
+    appName: "React Native Playground EN",
+};
+
+export default en;

--- a/app/src/translations/es.ts
+++ b/app/src/translations/es.ts
@@ -1,0 +1,5 @@
+const es = {
+    appName: "React Native Playground ES",
+};
+
+export default es;

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2476,6 +2476,10 @@ eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
 
+ex-react-native-i18n@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/ex-react-native-i18n/-/ex-react-native-i18n-0.0.4.tgz#a6685f87652880b6a7e5a6b7c81c40253a81103f"
+
 exec-sh@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
@@ -3365,6 +3369,12 @@ https-proxy-agent@^2.2.1:
   dependencies:
     agent-base "^4.1.0"
     debug "^3.1.0"
+
+i18n-ts@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/i18n-ts/-/i18n-ts-1.0.2.tgz#684a79f584fea35a3a7e1aff8a837f59bb3459f7"
+  dependencies:
+    typescript "2.7.1"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
@@ -6766,6 +6776,10 @@ typedarray-to-buffer@^3.1.2:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
 
 typescript@3.1.2:
   version "3.1.2"


### PR DESCRIPTION
### :tophat: What is the goal?

Internationalize our app.

### How is it being implemented?

We've configured [ts-i18n](https://github.com/sparkbitpl/i18n-ts) library and also [ex-react-native-i18n](https://github.com/xcarpentier/ex-react-native-i18n) letting us configure type safe copies for different languages. We needed to configure ``ex-react-native-i18n`` because we needed a sync API for loading the device locale and the current ``react-native-languages`` lib is not compatible with expo for now.

We've also configured a mock utility to be able to write tests easily using the English copies of our project.

### How can it be tested?

Automatically! :robot: I've added some automated tests I'd recommend you to review :smiley:
